### PR TITLE
Crosswalks

### DIFF
--- a/Sample/test.net.xml
+++ b/Sample/test.net.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on Thu 20 Feb 2020 06:19:54 PM CET by Eclipse SUMO netedit Version v1_3_1+0768-b8581b909d
+<!-- generated on 04/17/20 10:56:06 by Eclipse SUMO netedit Version 1.4.0
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/netconvertConfiguration.xsd">
 
     <input>
-        <sumo-net-file value="/home/patrick/School/Thesis/Data%20Analysis/SumoNetVis/Sample/test.net.xml"/>
+        <sumo-net-file value="Y:\SumoNetVis\Sample\test.net.xml"/>
     </input>
 
     <output>
-        <output-file value="/home/patrick/School/Thesis/Data%20Analysis/SumoNetVis/Sample/test.net.xml"/>
+        <output-file value="Y:\SumoNetVis\Sample\test.net.xml"/>
     </output>
 
     <processing>
+        <geometry.min-radius.fix.railways value="false"/>
         <geometry.max-grade.fix value="false"/>
         <offset.disable-normalization value="true"/>
         <lefthand value="false"/>
     </processing>
 
     <junctions>
+        <no-internal-links value="false"/>
         <no-turnarounds value="true"/>
         <junctions.corner-detail value="5"/>
         <junctions.limit-turn-speed value="5.5"/>
@@ -27,6 +29,10 @@
     <pedestrian>
         <walkingareas value="false"/>
     </pedestrian>
+
+    <report>
+        <aggregate-warnings value="5"/>
+    </report>
 
 </configuration>
 -->
@@ -57,6 +63,12 @@
     <edge id=":gneJ0_7" function="internal">
         <lane id=":gneJ0_7_0" index="0" speed="13.89" length="16.31" shape="-45.15,55.99 -28.84,56.02"/>
     </edge>
+    <edge id=":gneJ0_w0" function="walkingarea">
+        <lane id=":gneJ0_w0_0" index="0" allow="pedestrian" speed="1.00" length="13.53" width="3.20" shape="-41.56,49.00 -43.55,48.87 -45.20,51.19 -45.17,54.39 -45.17,54.39 -45.13,57.59 -45.13,57.59 -45.10,60.79 -45.10,60.79 -45.07,63.99 -28.94,64.02 -28.90,60.82 -28.90,60.82 -28.86,57.62 -28.86,57.62 -28.82,54.42 -28.82,54.42 -28.77,51.22 -30.18,49.71 -32.18,49.58"/>
+    </edge>
+    <edge id=":gneJ0_w1" function="walkingarea">
+        <lane id=":gneJ0_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-33.67,49.49 -36.87,49.29 -36.87,49.29 -40.06,49.09"/>
+    </edge>
     <edge id=":gneJ1_0" function="internal">
         <lane id=":gneJ1_0_0" index="0" speed="13.89" length="16.32" shape="84.42,64.01 68.12,63.70"/>
         <lane id=":gneJ1_0_1" index="1" speed="13.89" length="16.32" shape="84.50,60.81 68.17,60.50"/>
@@ -78,6 +90,12 @@
     </edge>
     <edge id=":gneJ1_7" function="internal">
         <lane id=":gneJ1_7_0" index="0" speed="13.89" length="16.37" shape="68.21,57.30 84.58,57.61"/>
+    </edge>
+    <edge id=":gneJ1_w0" function="walkingarea">
+        <lane id=":gneJ1_w0_0" index="0" allow="pedestrian" speed="1.00" length="13.56" width="3.20" shape="71.95,50.36 69.96,50.20 68.27,52.50 68.23,55.70 68.23,55.70 68.19,58.90 68.19,58.90 68.14,62.10 68.14,62.10 68.10,65.30 84.38,65.60 84.46,62.41 84.46,62.41 84.54,59.21 84.54,59.21 84.62,56.01 84.62,56.01 84.69,52.81 83.31,51.28 81.32,51.12"/>
+    </edge>
+    <edge id=":gneJ1_w1" function="walkingarea">
+        <lane id=":gneJ1_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="79.83,51.00 76.64,50.74 76.64,50.74 73.45,50.48"/>
     </edge>
     <edge id=":gneJ10_0" function="internal">
         <lane id=":gneJ10_0_0" index="0" allow="pedestrian" speed="4.83" length="4.68" width="2.00" shape="198.11,-37.57 197.04,-37.35 196.25,-36.73 195.75,-35.70 195.53,-34.28"/>
@@ -131,6 +149,24 @@
     <edge id=":gneJ10_14" function="internal">
         <lane id=":gneJ10_14_0" index="0" speed="8.64" length="15.92" shape="188.24,-34.61 189.02,-39.04 190.90,-42.22 193.89,-44.16 197.99,-44.87"/>
     </edge>
+    <edge id=":gneJ10_w0" function="walkingarea">
+        <lane id=":gneJ10_w0_0" index="0" allow="pedestrian" speed="1.00" length="4.18" width="2.00" shape="194.53,-34.33 196.53,-34.24 198.13,-36.57 198.10,-38.57 197.06,-38.43 196.20,-38.07 195.52,-37.48 195.01,-36.66 194.68,-35.61"/>
+    </edge>
+    <edge id=":gneJ10_w1" function="walkingarea">
+        <lane id=":gneJ10_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="198.07,-40.07 198.02,-43.27 198.02,-43.27 197.96,-46.47"/>
+    </edge>
+    <edge id=":gneJ10_w2" function="walkingarea">
+        <lane id=":gneJ10_w2_0" index="0" allow="pedestrian" speed="1.00" length="16.37" width="2.00" shape="197.93,-47.97 197.90,-49.96 181.53,-49.72 181.56,-47.72"/>
+    </edge>
+    <edge id=":gneJ10_w3" function="walkingarea">
+        <lane id=":gneJ10_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="181.58,-46.22 181.62,-43.02 181.62,-43.02 181.66,-39.82"/>
+    </edge>
+    <edge id=":gneJ10_w4" function="walkingarea">
+        <lane id=":gneJ10_w4_0" index="0" allow="pedestrian" speed="1.00" length="3.51" width="2.00" shape="181.68,-38.32 181.71,-36.32 183.14,-34.84 185.14,-34.75 185.09,-35.85 184.83,-36.75 184.36,-37.45 183.68,-37.94 182.78,-38.23"/>
+    </edge>
+    <edge id=":gneJ10_w5" function="walkingarea">
+        <lane id=":gneJ10_w5_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="186.64,-34.68 189.84,-34.54 189.84,-34.54 193.03,-34.40"/>
+    </edge>
     <edge id=":gneJ12_0" function="internal">
         <lane id=":gneJ12_0_0" index="0" allow="pedestrian" speed="3.09" length="1.59" width="2.00" shape="-22.99,-86.18 -23.42,-86.13 -23.73,-85.95 -23.93,-85.65 -24.00,-85.22"/>
     </edge>
@@ -148,6 +184,18 @@
     </edge>
     <edge id=":gneJ12_5" function="internal">
         <lane id=":gneJ12_5_0" index="0" speed="7.79" length="13.16" shape="-31.30,-85.52 -30.65,-89.06 -29.02,-91.57 -26.42,-93.04 -22.85,-93.48"/>
+    </edge>
+    <edge id=":gneJ12_w0" function="walkingarea">
+        <lane id=":gneJ12_w0_0" index="0" allow="pedestrian" speed="1.00" length="1.40" width="2.00" shape="-25.00,-85.26 -23.01,-85.18 -23.01,-85.18 -22.97,-87.18 -23.57,-87.14 -24.06,-86.98 -24.45,-86.72 -24.74,-86.35 -24.92,-85.86"/>
+    </edge>
+    <edge id=":gneJ12_w1" function="walkingarea">
+        <lane id=":gneJ12_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-22.94,-88.68 -22.88,-91.88 -22.88,-91.88 -22.83,-95.08"/>
+    </edge>
+    <edge id=":gneJ12_w2" function="walkingarea">
+        <lane id=":gneJ12_w2_0" index="0" allow="pedestrian" speed="1.00" length="17.33" width="2.00" shape="-22.80,-96.58 -22.76,-98.58 -36.39,-85.73 -34.40,-85.65 -33.95,-89.05 -32.90,-91.81 -31.27,-93.95 -29.04,-95.46 -26.21,-96.33"/>
+    </edge>
+    <edge id=":gneJ12_w3" function="walkingarea">
+        <lane id=":gneJ12_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-32.90,-85.59 -29.70,-85.46 -29.70,-85.46 -26.50,-85.33"/>
     </edge>
     <edge id=":gneJ13_0" function="internal">
         <lane id=":gneJ13_0_0" index="0" allow="pedestrian" speed="6.68" length="6.49" width="2.00" shape="97.29,-86.67 96.40,-86.01 95.72,-84.83 95.24,-83.12 94.96,-80.89"/>
@@ -201,6 +249,27 @@
     <edge id=":gneJ13_14" function="internal">
         <lane id=":gneJ13_14_0" index="0" speed="9.92" length="14.62" shape="87.68,-81.40 88.36,-85.73 89.74,-89.18 91.80,-91.75 94.56,-93.44"/>
     </edge>
+    <edge id=":gneJ13_w0" function="walkingarea">
+        <lane id=":gneJ13_w0_0" index="0" allow="pedestrian" speed="1.00" length="6.24" width="2.00" shape="93.96,-80.96 95.96,-80.82 97.66,-85.75 96.91,-87.60 96.12,-87.13 95.45,-86.41 94.90,-85.43 94.47,-84.19 94.16,-82.70"/>
+    </edge>
+    <edge id=":gneJ13_w1" function="walkingarea">
+        <lane id=":gneJ13_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.39" width="3.20" shape="96.35,-88.99 95.15,-91.96 95.16,-91.96 93.96,-94.92"/>
+    </edge>
+    <edge id=":gneJ13_w2" function="walkingarea">
+        <lane id=":gneJ13_w2_0" index="0" allow="pedestrian" speed="1.00" length="11.71" width="2.00" shape="93.40,-96.32 92.65,-98.17 81.44,-96.68 81.41,-94.68 84.01,-94.61 85.96,-94.56 87.57,-94.61 89.14,-94.86 90.98,-95.40"/>
+    </edge>
+    <edge id=":gneJ13_w3" function="walkingarea">
+        <lane id=":gneJ13_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="81.38,-93.19 81.32,-89.99 81.32,-89.99 81.26,-86.79"/>
+    </edge>
+    <edge id=":gneJ13_w4" function="walkingarea">
+        <lane id=":gneJ13_w4_0" index="0" allow="pedestrian" speed="1.00" length="3.52" width="2.00" shape="81.24,-85.29 81.20,-83.29 82.59,-81.76 84.59,-81.62 84.57,-82.72 84.33,-83.63 83.88,-84.34 83.21,-84.85 82.33,-85.17"/>
+    </edge>
+    <edge id=":gneJ13_w5" function="walkingarea">
+        <lane id=":gneJ13_w5_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="86.08,-81.52 89.28,-81.29 89.28,-81.29 92.47,-81.06"/>
+    </edge>
+    <edge id=":gneJ14_w0" function="walkingarea">
+        <lane id=":gneJ14_w0_0" index="0" allow="pedestrian" speed="1.00" length="9.60" width="3.20" shape="-210.20,59.49 -210.24,56.29 -210.24,56.29 -210.28,53.09 -210.12,65.89 -210.16,62.69 -210.16,62.69 -210.20,59.49"/>
+    </edge>
     <edge id=":gneJ15_0" function="internal">
         <lane id=":gneJ15_0_0" index="0" allow="bicycle" speed="13.89" length="16.27" width="1.50" shape="347.09,-44.67 343.62,-44.23 340.24,-43.21 336.28,-42.17 331.02,-41.63"/>
         <lane id=":gneJ15_0_1" index="1" speed="13.89" length="16.27" shape="347.09,-44.67 330.99,-43.38"/>
@@ -229,6 +298,15 @@
     <edge id=":gneJ15_9" function="internal">
         <lane id=":gneJ15_9_0" index="0" allow="bicycle" speed="13.89" length="16.29" width="1.50" shape="330.91,-48.03 336.17,-47.84 340.18,-47.29 343.60,-46.70 347.10,-46.42"/>
     </edge>
+    <edge id=":gneJ15_w1" function="walkingarea">
+        <lane id=":gneJ15_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="342.27,-53.54 339.07,-53.63 339.07,-53.63 335.87,-53.71"/>
+    </edge>
+    <edge id=":gneJ15_w2" function="walkingarea">
+        <lane id=":gneJ15_w2_0" index="0" allow="pedestrian" speed="1.00" length="3.55" width="2.00" shape="334.38,-53.75 332.38,-53.81 330.84,-52.28 330.87,-50.28 331.92,-50.39 332.78,-50.69 333.45,-51.18 333.95,-51.85 334.25,-52.71"/>
+    </edge>
+    <edge id=":gneJ15_w3" function="walkingarea">
+        <lane id=":gneJ15_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="330.90,-48.78 330.95,-45.58 330.95,-45.58 331.01,-42.38"/>
+    </edge>
     <edge id=":gneJ16_0" function="internal">
         <lane id=":gneJ16_0_0" index="0" allow="pedestrian" speed="9.31" length="20.31" width="2.00" shape="335.26,-170.14 340.78,-169.32 344.67,-166.93 346.94,-162.96 347.58,-157.41"/>
     </edge>
@@ -246,6 +324,18 @@
     </edge>
     <edge id=":gneJ16_5" function="internal">
         <lane id=":gneJ16_5_0" index="0" speed="6.24" length="8.35" shape="340.29,-157.61 340.02,-159.89 339.09,-161.52 337.49,-162.51 335.22,-162.85"/>
+    </edge>
+    <edge id=":gneJ16_w0" function="walkingarea">
+        <lane id=":gneJ16_w0_0" index="0" allow="pedestrian" speed="1.00" length="17.72" width="2.00" shape="346.58,-157.44 348.58,-157.39 335.26,-171.14 335.25,-169.14 338.80,-168.80 341.69,-167.82 343.91,-166.19 345.46,-163.92 346.36,-161.00"/>
+    </edge>
+    <edge id=":gneJ16_w1" function="walkingarea">
+        <lane id=":gneJ16_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.39" width="3.20" shape="335.24,-167.64 335.23,-164.44 335.23,-164.45 335.21,-161.25"/>
+    </edge>
+    <edge id=":gneJ16_w2" function="walkingarea">
+        <lane id=":gneJ16_w2_0" index="0" allow="pedestrian" speed="1.00" length="1.43" width="2.00" shape="335.20,-159.75 335.19,-157.75 335.19,-157.75 337.19,-157.69 337.15,-158.32 336.99,-158.83 336.72,-159.23 336.33,-159.52 335.82,-159.69"/>
+    </edge>
+    <edge id=":gneJ16_w3" function="walkingarea">
+        <lane id=":gneJ16_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="338.69,-157.65 341.88,-157.57 341.88,-157.57 345.08,-157.48"/>
     </edge>
     <edge id=":gneJ2_0" function="internal">
         <lane id=":gneJ2_0_0" index="0" allow="pedestrian" speed="5.33" length="5.78" width="2.00" shape="89.34,10.66 87.68,10.84 86.46,11.44 85.67,12.46 85.32,13.88"/>
@@ -349,6 +439,33 @@
     <edge id=":gneJ2_27" function="internal">
         <lane id=":gneJ2_27_0" index="0" speed="8.93" length="16.96" shape="78.05,13.29 79.06,8.91 81.29,5.79 84.74,3.94 89.41,3.36"/>
     </edge>
+    <edge id=":gneJ2_c0" function="crossing" crossingEdges="-gneE2 gneE2">
+        <lane id=":gneJ2_c0_0" index="0" allow="pedestrian" speed="1.00" length="12.71" width="4.00" customShape="1" shape="70.77,9.98 70.64,5.77 74.52,-1.79"/>
+    </edge>
+    <edge id=":gneJ2_w0" function="walkingarea">
+        <lane id=":gneJ2_w0_0" index="0" allow="pedestrian" speed="1.00" length="5.15" width="2.00" shape="84.33,13.80 86.32,13.96 89.33,11.66 89.35,9.66 87.91,9.76 86.71,10.10 85.75,10.67 85.03,11.48 84.56,12.52"/>
+    </edge>
+    <edge id=":gneJ2_w1" function="walkingarea">
+        <lane id=":gneJ2_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="89.37,8.16 89.40,4.96 89.40,4.96 89.43,1.76"/>
+    </edge>
+    <edge id=":gneJ2_w2" function="walkingarea">
+        <lane id=":gneJ2_w2_0" index="0" allow="pedestrian" speed="1.00" length="3.49" width="2.00" shape="89.44,0.26 89.46,-1.74 88.16,-3.24 86.18,-3.51 86.13,-2.37 86.32,-1.43 86.75,-0.70 87.41,-0.18 88.31,0.14"/>
+    </edge>
+    <edge id=":gneJ2_w3" function="walkingarea">
+        <lane id=":gneJ2_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="84.69,-3.70 81.52,-4.12 81.52,-4.12 78.34,-4.54"/>
+    </edge>
+    <edge id=":gneJ2_w4" function="walkingarea">
+        <lane id=":gneJ2_w4_0" index="0" allow="pedestrian" speed="1.00" length="3.86" width="4.00" shape="76.86,-4.73 74.87,-5.00 71.92,-2.04 71.87,-0.05 72.74,-2.70 73.22,-0.15 74.36,-0.52 75.29,-1.16 76.02,-2.08 76.54,-3.27"/>
+    </edge>
+    <edge id=":gneJ2_w5" function="walkingarea">
+        <lane id=":gneJ2_w5_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="71.83,1.45 71.75,4.65 71.75,4.65 71.67,7.85"/>
+    </edge>
+    <edge id=":gneJ2_w6" function="walkingarea">
+        <lane id=":gneJ2_w6_0" index="0" allow="pedestrian" speed="1.00" length="2.93" width="4.00" shape="68.77,10.04 71.63,9.35 71.58,11.35 72.96,12.88 74.96,13.04 74.94,11.94 74.72,11.03 74.27,10.32 73.61,9.80 72.73,9.48"/>
+    </edge>
+    <edge id=":gneJ2_w7" function="walkingarea">
+        <lane id=":gneJ2_w7_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="76.45,13.16 79.64,13.42 79.64,13.42 82.83,13.68"/>
+    </edge>
     <edge id=":gneJ3_0" function="internal">
         <lane id=":gneJ3_0_0" index="0" allow="pedestrian" speed="5.29" length="5.84" width="2.00" shape="-25.67,7.89 -26.96,8.12 -27.91,8.89 -28.54,10.19 -28.84,12.03"/>
     </edge>
@@ -374,7 +491,7 @@
         <lane id=":gneJ3_7_0" index="0" allow="pedestrian" speed="4.40" length="4.05" width="2.00" shape="-27.77,-6.10 -27.67,-4.99 -27.24,-4.19 -26.48,-3.69 -25.38,-3.51"/>
     </edge>
     <edge id=":gneJ3_8" function="internal">
-        <lane id=":gneJ3_8_0" index="0" allow="bicycle" speed="5.53" length="6.93" width="1.50" shape="-29.52,-6.19 -29.35,-4.29 -28.61,-2.92 -27.30,-2.07 -25.42,-1.76"/>
+        <lane id=":gneJ3_8_0" index="0" allow="bicycle" speed="5.53" length="1.91" width="1.50" shape="-29.52,-6.19 -29.35,-4.29"/>
     </edge>
     <edge id=":gneJ3_9" function="internal">
         <lane id=":gneJ3_9_0" index="0" allow="bicycle" speed="13.89" length="18.15" width="1.50" shape="-29.52,-6.19 -30.58,11.92"/>
@@ -392,13 +509,16 @@
         <lane id=":gneJ3_13_0" index="0" speed="9.56" length="5.20" shape="-31.87,-6.32 -32.78,-1.98 -33.20,-1.34"/>
     </edge>
     <edge id=":gneJ3_28" function="internal">
-        <lane id=":gneJ3_28_0" index="0" allow="bicycle" speed="10.08" length="16.53" width="1.50" shape="-30.58,-2.72 -30.87,-1.76 -34.02,2.38 -38.28,5.59 -42.99,7.25"/>
+        <lane id=":gneJ3_28_0" index="0" allow="bicycle" speed="5.53" length="5.02" width="1.50" shape="-29.35,-4.29 -28.61,-2.92 -27.30,-2.07 -25.42,-1.76"/>
     </edge>
     <edge id=":gneJ3_29" function="internal">
-        <lane id=":gneJ3_29_0" index="0" speed="6.98" length="7.04" shape="-31.23,-2.66 -30.45,-1.22 -28.41,0.10 -25.48,0.59"/>
+        <lane id=":gneJ3_29_0" index="0" allow="bicycle" speed="10.08" length="16.53" width="1.50" shape="-30.58,-2.72 -30.87,-1.76 -34.02,2.38 -38.28,5.59 -42.99,7.25"/>
     </edge>
     <edge id=":gneJ3_30" function="internal">
-        <lane id=":gneJ3_30_0" index="0" speed="9.56" length="12.41" shape="-33.20,-1.34 -34.99,1.34 -38.51,3.64 -43.32,4.92"/>
+        <lane id=":gneJ3_30_0" index="0" speed="6.98" length="7.04" shape="-31.23,-2.66 -30.45,-1.22 -28.41,0.10 -25.48,0.59"/>
+    </edge>
+    <edge id=":gneJ3_31" function="internal">
+        <lane id=":gneJ3_31_0" index="0" speed="9.56" length="12.41" shape="-33.20,-1.34 -34.99,1.34 -38.51,3.64 -43.32,4.92"/>
     </edge>
     <edge id=":gneJ3_14" function="internal">
         <lane id=":gneJ3_14_0" index="0" allow="pedestrian" speed="6.27" length="7.43" width="2.00" shape="-44.34,-2.33 -42.15,-2.86 -40.55,-3.77 -39.55,-5.05 -39.15,-6.72"/>
@@ -425,7 +545,7 @@
         <lane id=":gneJ3_21_0" index="0" allow="pedestrian" speed="4.22" length="4.14" width="2.00" shape="-40.21,11.32 -40.31,10.16 -40.76,9.38 -41.57,8.99 -42.74,8.98"/>
     </edge>
     <edge id=":gneJ3_22" function="internal">
-        <lane id=":gneJ3_22_0" index="0" allow="bicycle" speed="5.39" length="7.40" width="1.50" shape="-38.47,11.43 -38.64,9.35 -39.45,7.96 -40.90,7.26 -42.99,7.25"/>
+        <lane id=":gneJ3_22_0" index="0" allow="bicycle" speed="5.39" length="1.81" width="1.50" shape="-38.47,11.43 -38.61,9.63"/>
     </edge>
     <edge id=":gneJ3_23" function="internal">
         <lane id=":gneJ3_23_0" index="0" allow="bicycle" speed="13.89" length="18.08" width="1.50" shape="-38.47,11.43 -37.41,-6.62"/>
@@ -442,14 +562,53 @@
     <edge id=":gneJ3_27" function="internal">
         <lane id=":gneJ3_27_0" index="0" speed="8.89" length="6.09" shape="-36.12,11.58 -35.19,6.68 -34.62,5.73"/>
     </edge>
-    <edge id=":gneJ3_31" function="internal">
-        <lane id=":gneJ3_31_0" index="0" allow="bicycle" speed="9.40" length="15.83" width="1.50" shape="-37.33,7.47 -37.12,6.75 -34.09,2.47 -29.98,-0.63 -25.42,-1.76"/>
-    </edge>
     <edge id=":gneJ3_32" function="internal">
-        <lane id=":gneJ3_32_0" index="0" speed="6.88" length="7.75" shape="-36.74,7.65 -37.68,6.05 -39.99,4.93 -43.32,4.92"/>
+        <lane id=":gneJ3_32_0" index="0" allow="bicycle" speed="5.39" length="5.59" width="1.50" shape="-38.61,9.63 -38.64,9.35 -39.45,7.96 -40.90,7.26 -42.99,7.25"/>
     </edge>
     <edge id=":gneJ3_33" function="internal">
-        <lane id=":gneJ3_33_0" index="0" speed="8.89" length="11.19" shape="-34.62,5.73 -33.11,3.21 -29.88,1.19 -25.48,0.59"/>
+        <lane id=":gneJ3_33_0" index="0" allow="bicycle" speed="9.40" length="15.83" width="1.50" shape="-37.33,7.47 -37.12,6.75 -34.09,2.47 -29.98,-0.63 -25.42,-1.76"/>
+    </edge>
+    <edge id=":gneJ3_34" function="internal">
+        <lane id=":gneJ3_34_0" index="0" speed="6.88" length="7.75" shape="-36.74,7.65 -37.68,6.05 -39.99,4.93 -43.32,4.92"/>
+    </edge>
+    <edge id=":gneJ3_35" function="internal">
+        <lane id=":gneJ3_35_0" index="0" speed="8.89" length="11.19" shape="-34.62,5.73 -33.11,3.21 -29.88,1.19 -25.48,0.59"/>
+    </edge>
+    <edge id=":gneJ3_c0" function="crossing" crossingEdges="gneE2 -gneE2">
+        <lane id=":gneJ3_c0_0" index="0" allow="pedestrian" speed="1.00" length="9.40" width="4.00" shape="-27.41,-2.56 -27.64,6.84"/>
+    </edge>
+    <edge id=":gneJ3_c1" function="crossing" crossingEdges="gneE7 -gneE7">
+        <lane id=":gneJ3_c1_0" index="0" allow="pedestrian" speed="1.00" length="9.40" width="4.00" shape="-38.27,-4.66 -28.88,-4.15"/>
+    </edge>
+    <edge id=":gneJ3_c2" function="crossing" crossingEdges="gneE5 -gneE5">
+        <lane id=":gneJ3_c2_0" index="0" allow="pedestrian" speed="1.00" length="9.42" width="4.00" shape="-40.90,7.71 -42.22,-1.61"/>
+    </edge>
+    <edge id=":gneJ3_c3" function="crossing" crossingEdges="gneE3 -gneE3">
+        <lane id=":gneJ3_c3_0" index="0" allow="pedestrian" speed="1.00" length="9.40" width="4.00" shape="-29.71,9.97 -39.09,9.39"/>
+    </edge>
+    <edge id=":gneJ3_w0" function="walkingarea">
+        <lane id=":gneJ3_w0_0" index="0" allow="pedestrian" speed="1.00" length="3.89" width="4.00" shape="-29.83,11.97 -27.84,12.09 -25.69,8.89 -25.64,6.89 -26.83,7.00 -27.83,7.41 -28.62,8.11 -29.22,9.10 -29.63,10.39"/>
+    </edge>
+    <edge id=":gneJ3_w1" function="walkingarea">
+        <lane id=":gneJ3_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-25.61,5.39 -25.52,2.19 -25.52,2.19 -25.44,-1.01"/>
+    </edge>
+    <edge id=":gneJ3_w2" function="walkingarea">
+        <lane id=":gneJ3_w2_0" index="0" allow="pedestrian" speed="1.00" length="2.88" width="4.00" shape="-25.41,-2.51 -25.36,-4.51 -26.77,-6.04 -28.77,-6.15 -28.73,-5.06 -28.48,-4.17 -28.03,-3.46 -27.36,-2.95 -26.49,-2.63"/>
+    </edge>
+    <edge id=":gneJ3_w3" function="walkingarea">
+        <lane id=":gneJ3_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-30.27,-6.23 -33.46,-6.41 -33.46,-6.41 -36.66,-6.58"/>
+    </edge>
+    <edge id=":gneJ3_w4" function="walkingarea">
+        <lane id=":gneJ3_w4_0" index="0" allow="pedestrian" speed="1.00" length="4.79" width="4.00" shape="-38.16,-6.66 -40.15,-6.77 -44.48,-3.32 -44.20,-1.34 -42.42,-1.71 -40.95,-2.29 -39.79,-3.07 -38.94,-4.06 -38.39,-5.26"/>
+    </edge>
+    <edge id=":gneJ3_w5" function="walkingarea">
+        <lane id=":gneJ3_w5_0" index="0" allow="pedestrian" speed="1.00" length="11.42" width="3.20" shape="-43.99,0.15 -43.55,3.32 -43.54,3.34 -43.09,6.51"/>
+    </edge>
+    <edge id=":gneJ3_w6" function="walkingarea">
+        <lane id=":gneJ3_w6_0" index="0" allow="pedestrian" speed="1.00" length="2.96" width="4.00" shape="-42.88,7.99 -42.60,9.97 -41.21,11.26 -39.22,11.39 -39.25,10.20 -39.51,9.26 -40.01,8.57 -40.74,8.13 -41.69,7.93"/>
+    </edge>
+    <edge id=":gneJ3_w7" function="walkingarea">
+        <lane id=":gneJ3_w7_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-37.72,11.48 -34.52,11.68 -34.52,11.68 -31.33,11.88"/>
     </edge>
     <edge id=":gneJ4_0" function="internal">
         <lane id=":gneJ4_0_0" index="0" speed="13.89" length="16.95" shape="-114.56,63.08 -131.51,63.27"/>
@@ -473,6 +632,12 @@
     <edge id=":gneJ4_7" function="internal">
         <lane id=":gneJ4_7_0" index="0" speed="13.89" length="16.97" shape="-131.60,56.87 -114.63,56.68"/>
     </edge>
+    <edge id=":gneJ4_w0" function="walkingarea">
+        <lane id=":gneJ4_w0_0" index="0" allow="pedestrian" speed="1.00" length="14.35" width="3.20" shape="-126.69,47.28 -128.61,46.72 -131.66,52.07 -131.62,55.27 -131.62,55.27 -131.58,58.47 -131.58,58.47 -131.53,61.67 -131.53,61.67 -131.49,64.86 -114.55,64.68 -114.58,61.48 -114.58,61.48 -114.61,58.28 -114.61,58.28 -114.64,55.08 -114.64,55.08 -114.68,51.88 -115.76,50.45 -117.68,49.89"/>
+    </edge>
+    <edge id=":gneJ4_w1" function="walkingarea">
+        <lane id=":gneJ4_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.38" width="3.20" shape="-119.12,49.47 -122.20,48.59 -122.18,48.59 -125.25,47.70"/>
+    </edge>
     <edge id=":gneJ5_0" function="internal">
         <lane id=":gneJ5_0_0" index="0" speed="13.89" length="16.45" shape="193.82,66.60 177.36,66.24"/>
         <lane id=":gneJ5_0_1" index="1" speed="13.89" length="16.45" shape="193.88,63.40 177.43,63.05"/>
@@ -494,6 +659,12 @@
     </edge>
     <edge id=":gneJ5_7" function="internal">
         <lane id=":gneJ5_7_0" index="0" speed="13.89" length="16.43" shape="177.51,59.85 193.94,60.20"/>
+    </edge>
+    <edge id=":gneJ5_w0" function="walkingarea">
+        <lane id=":gneJ5_w0_0" index="0" allow="pedestrian" speed="1.00" length="13.49" width="3.20" shape="181.21,53.36 179.21,53.27 177.63,55.05 177.55,58.25 177.55,58.25 177.47,61.45 177.47,61.45 177.40,64.64 177.40,64.64 177.32,67.84 193.79,68.20 193.85,65.00 193.85,65.00 193.91,61.80 193.91,61.80 193.97,58.60 193.97,58.60 194.03,55.40 192.59,53.87 190.60,53.78"/>
+    </edge>
+    <edge id=":gneJ5_w1" function="walkingarea">
+        <lane id=":gneJ5_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="189.10,53.72 185.90,53.57 185.90,53.57 182.70,53.43"/>
     </edge>
     <edge id=":gneJ6_0" function="internal">
         <lane id=":gneJ6_0_0" index="0" allow="pedestrian" speed="4.59" length="4.27" width="2.00" shape="-23.21,-38.76 -24.43,-38.63 -25.33,-38.19 -25.89,-37.43 -26.12,-36.36"/>
@@ -546,6 +717,24 @@
     </edge>
     <edge id=":gneJ6_17" function="internal">
         <lane id=":gneJ6_17_0" index="0" speed="8.50" length="9.73" shape="-31.54,-42.42 -30.56,-43.85 -27.38,-45.56 -23.03,-46.06"/>
+    </edge>
+    <edge id=":gneJ6_w0" function="walkingarea">
+        <lane id=":gneJ6_w0_0" index="0" allow="pedestrian" speed="1.00" length="3.77" width="2.00" shape="-27.12,-36.41 -25.13,-36.30 -23.24,-37.76 -23.19,-39.76 -24.34,-39.69 -25.29,-39.43 -26.04,-38.97 -26.60,-38.31 -26.96,-37.46"/>
+    </edge>
+    <edge id=":gneJ6_w1" function="walkingarea">
+        <lane id=":gneJ6_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-23.15,-41.26 -23.07,-44.46 -23.07,-44.46 -22.99,-47.65"/>
+    </edge>
+    <edge id=":gneJ6_w2" function="walkingarea">
+        <lane id=":gneJ6_w2_0" index="0" allow="pedestrian" speed="1.00" length="3.53" width="2.00" shape="-22.95,-49.15 -22.91,-51.15 -24.34,-52.69 -26.34,-52.77 -26.29,-51.69 -26.03,-50.80 -25.57,-50.10 -24.90,-49.59 -24.03,-49.28"/>
+    </edge>
+    <edge id=":gneJ6_w3" function="walkingarea">
+        <lane id=":gneJ6_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-27.84,-52.83 -31.04,-52.96 -31.04,-52.96 -34.24,-53.10"/>
+    </edge>
+    <edge id=":gneJ6_w4" function="walkingarea">
+        <lane id=":gneJ6_w4_0" index="0" allow="pedestrian" speed="1.00" length="16.24" width="2.00" shape="-35.73,-53.16 -37.73,-53.24 -38.51,-37.03 -36.51,-36.92"/>
+    </edge>
+    <edge id=":gneJ6_w5" function="walkingarea">
+        <lane id=":gneJ6_w5_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="-35.01,-36.84 -31.82,-36.67 -31.82,-36.67 -28.62,-36.49"/>
     </edge>
     <edge id=":gneJ7_0" function="internal">
         <lane id=":gneJ7_0_0" index="0" allow="pedestrian" speed="5.82" length="6.60" width="2.00" shape="95.34,-36.18 93.62,-35.90 92.32,-35.14 91.43,-33.89 90.96,-32.14"/>
@@ -648,6 +837,39 @@
     </edge>
     <edge id=":gneJ7_27" function="internal">
         <lane id=":gneJ7_27_0" index="0" speed="9.25" length="17.18" shape="83.72,-33.09 84.95,-37.58 87.28,-40.81 90.71,-42.78 95.24,-43.48"/>
+    </edge>
+    <edge id=":gneJ7_w0" function="walkingarea">
+        <lane id=":gneJ7_w0_0" index="0" allow="pedestrian" speed="1.00" length="5.96" width="2.00" shape="89.97,-32.27 91.95,-32.01 95.35,-35.18 95.33,-37.18 93.87,-37.02 92.63,-36.60 91.63,-35.92 90.85,-34.97 90.30,-33.75"/>
+    </edge>
+    <edge id=":gneJ7_w1" function="walkingarea">
+        <lane id=":gneJ7_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="95.31,-38.68 95.27,-41.88 95.27,-41.88 95.22,-45.08"/>
+    </edge>
+    <edge id=":gneJ7_w2" function="walkingarea">
+        <lane id=":gneJ7_w2_0" index="0" allow="pedestrian" speed="1.00" length="3.50" width="2.00" shape="95.20,-46.58 95.18,-48.58 93.78,-50.05 91.79,-50.19 91.81,-49.07 92.05,-48.16 92.51,-47.46 93.19,-46.96 94.09,-46.66"/>
+    </edge>
+    <edge id=":gneJ7_w3" function="walkingarea">
+        <lane id=":gneJ7_w3_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="90.29,-50.30 87.10,-50.52 87.10,-50.52 83.91,-50.75"/>
+    </edge>
+    <edge id=":gneJ7_w4" function="walkingarea">
+        <lane id=":gneJ7_w4_0" index="0" allow="pedestrian" speed="1.00" length="4.96" width="2.00" shape="82.41,-50.86 80.42,-51.00 77.69,-48.68 77.64,-46.68 79.02,-46.76 80.16,-47.09 81.07,-47.67 81.75,-48.49 82.19,-49.55"/>
+    </edge>
+    <edge id=":gneJ7_w5" function="walkingarea">
+        <lane id=":gneJ7_w5_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="77.61,-45.18 77.53,-41.98 77.53,-41.98 77.45,-38.78"/>
+    </edge>
+    <edge id=":gneJ7_w6" function="walkingarea">
+        <lane id=":gneJ7_w6_0" index="0" allow="pedestrian" speed="1.00" length="3.49" width="2.00" shape="77.41,-37.28 77.36,-35.28 78.67,-33.76 80.65,-33.50 80.69,-34.63 80.51,-35.56 80.08,-36.29 79.43,-36.82 78.54,-37.15"/>
+    </edge>
+    <edge id=":gneJ7_w7" function="walkingarea">
+        <lane id=":gneJ7_w7_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="82.14,-33.30 85.31,-32.88 85.31,-32.88 88.48,-32.46"/>
+    </edge>
+    <edge id=":gneJ8_w0" function="walkingarea">
+        <lane id=":gneJ8_w0_0" index="0" allow="pedestrian" speed="1.00" length="9.60" width="3.20" shape="289.96,63.61 289.90,66.81 289.90,66.81 289.84,70.01 290.08,57.21 290.02,60.41 290.02,60.41 289.96,63.61"/>
+    </edge>
+    <edge id=":gneJ9_w0" function="walkingarea">
+        <lane id=":gneJ9_w0_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="3.20" shape="138.63,2.23 138.60,5.43 138.60,5.43 138.57,8.63"/>
+    </edge>
+    <edge id=":gneJ9_w1" function="walkingarea">
+        <lane id=":gneJ9_w1_0" index="0" allow="pedestrian" speed="1.00" length="11.40" width="2.00" shape="138.55,10.13 138.54,12.13 138.66,-1.27 138.65,0.73"/>
     </edge>
 
     <edge id="-gneE0" from="gneJ1" to="gneJ0" priority="-1">
@@ -941,65 +1163,70 @@
         <request index="5" response="000000" foes="000000" cont="0"/>
     </junction>
     <junction id="gneJ18" type="dead_end" x="438.30" y="-45.06" incLanes="gneE22_0" intLanes="" shape="438.30,-45.06 438.31,-46.56 438.30,-45.06"/>
-    <junction id="gneJ2" type="priority" x="80.33" y="4.87" incLanes="-gneE11_0 -gneE11_1 -gneE11_2 -gneE9_0 -gneE9_1 -gneE9_2 gneE2_0 gneE2_1 gneE2_2 gneE1_0 gneE1_1 gneE1_2" intLanes=":gneJ2_0_0 :gneJ2_1_0 :gneJ2_2_0 :gneJ2_28_0 :gneJ2_29_0 :gneJ2_5_0 :gneJ2_30_0 :gneJ2_7_0 :gneJ2_8_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_11_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_14_0 :gneJ2_15_0 :gneJ2_16_0 :gneJ2_31_0 :gneJ2_32_0 :gneJ2_19_0 :gneJ2_33_0 :gneJ2_21_0 :gneJ2_22_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_25_0 :gneJ2_26_0 :gneJ2_27_0" shape="89.33,11.66 89.46,-1.74 88.65,-1.92 88.39,-2.13 88.22,-2.42 88.14,-2.79 88.16,-3.24 74.87,-5.00 74.37,-3.33 73.94,-2.75 73.39,-2.34 72.71,-2.11 71.92,-2.04 71.58,11.35 72.40,11.54 72.68,11.75 72.86,12.05 72.96,12.43 72.96,12.88 86.32,13.96 86.74,12.67 87.17,12.22 87.74,11.90 88.46,11.71">
-        <request index="0"  response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="1"  response="0000000000000000000000000000" foes="0000000000100000001000000000" cont="0"/>
-        <request index="2"  response="0000000000000000000000000000" foes="1111110100100001011000010000" cont="0"/>
-        <request index="3"  response="0000000011011000000000100000" foes="1101100011011011011000110000" cont="1"/>
-        <request index="4"  response="0000000000000000000000001100" foes="0000000100100001001000001100" cont="1"/>
-        <request index="5"  response="0000000000000000000000000000" foes="1111100100100011011000001000" cont="0"/>
-        <request index="6"  response="0000000011010000000000000000" foes="1101000011010011011000000000" cont="1"/>
-        <request index="7"  response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="8"  response="0000000000010000000000000000" foes="0001000000010000000000000000" cont="0"/>
-        <request index="9"  response="0000000010110000000001111110" foes="1001000010110000100001111110" cont="0"/>
-        <request index="10" response="1111110110110001000001101100" foes="1111110110110001100001101100" cont="0"/>
-        <request index="11" response="0000000010010000011000000000" foes="1001000010010000011000000000" cont="0"/>
-        <request index="12" response="0000000110110000000001111100" foes="1001000110110000010001111100" cont="0"/>
-        <request index="13" response="0110100110110000000001101000" foes="0110100110110000000001101000" cont="0"/>
-        <request index="14" response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="15" response="0000000000000000000000000000" foes="0000100000000000000000001000" cont="0"/>
-        <request index="16" response="0000000000000000000000000000" foes="0101100001000011111101001000" cont="0"/>
-        <request index="17" response="0000000010000000000000110110" foes="1101100011000011011000110110" cont="1"/>
-        <request index="18" response="0000000000110000000000000000" foes="0100100000110000000001001000" cont="1"/>
-        <request index="19" response="0000000000000000000000000000" foes="1101100000100011111001001000" cont="0"/>
-        <request index="20" response="0000000000000000000000110100" foes="1101100000000011010000110100" cont="1"/>
-        <request index="21" response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="22" response="0000000000000000000000000100" foes="0000000000000000010000000100" cont="0"/>
-        <request index="23" response="0000000111111000000000101100" foes="0010000111111010010000101100" cont="0"/>
-        <request index="24" response="0100000110110001101101101100" foes="0110000110110011111101101100" cont="0"/>
-        <request index="25" response="0001100000000000000000100100" foes="0001100000000010010000100100" cont="0"/>
-        <request index="26" response="0000000111110000000001101100" foes="0001000111110010010001101100" cont="0"/>
-        <request index="27" response="0000000110100001101001101100" foes="0000000110100001101001101100" cont="0"/>
+    <junction id="gneJ2" type="priority" x="80.33" y="4.87" incLanes="-gneE11_0 -gneE11_1 -gneE11_2 -gneE9_0 -gneE9_1 -gneE9_2 gneE2_0 gneE2_1 gneE2_2 gneE1_0 gneE1_1 gneE1_2 :gneJ2_w6_0" intLanes=":gneJ2_0_0 :gneJ2_1_0 :gneJ2_2_0 :gneJ2_28_0 :gneJ2_29_0 :gneJ2_5_0 :gneJ2_30_0 :gneJ2_7_0 :gneJ2_8_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_11_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_14_0 :gneJ2_15_0 :gneJ2_16_0 :gneJ2_31_0 :gneJ2_32_0 :gneJ2_19_0 :gneJ2_33_0 :gneJ2_21_0 :gneJ2_22_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_25_0 :gneJ2_26_0 :gneJ2_27_0 :gneJ2_c0_0" shape="89.33,11.66 89.46,-1.74 88.65,-1.92 88.39,-2.13 88.22,-2.42 88.14,-2.79 88.16,-3.24 74.87,-5.00 74.37,-3.33 73.94,-2.75 73.39,-2.34 72.71,-2.11 71.92,-2.04 71.58,11.35 72.40,11.54 72.68,11.75 72.86,12.05 72.96,12.43 72.96,12.88 86.32,13.96 86.74,12.67 87.17,12.22 87.74,11.90 88.46,11.71">
+        <request index="0"  response="00000000000000000000000000000" foes="00000000000000000000000000000" cont="0"/>
+        <request index="1"  response="00000000000000000000000000000" foes="00000000000100000001000000000" cont="0"/>
+        <request index="2"  response="00000000000000000000000000000" foes="11111110100100001011000010000" cont="0"/>
+        <request index="3"  response="00000000011011000000000100000" foes="01101100011011011011000110000" cont="1"/>
+        <request index="4"  response="00000000000000000000000001100" foes="00000000100100001001000001100" cont="1"/>
+        <request index="5"  response="00000000000000000000000000000" foes="11111100100100011011000001000" cont="0"/>
+        <request index="6"  response="00000000011010000000000000000" foes="01101000011010011011000000000" cont="1"/>
+        <request index="7"  response="00000000000000000000000000000" foes="00000000000000000000000000000" cont="0"/>
+        <request index="8"  response="00000000000010000000000000000" foes="00001000000010000000000000000" cont="0"/>
+        <request index="9"  response="00000000010110000000001111110" foes="01001000010110000100001111110" cont="0"/>
+        <request index="10" response="11111110110110001000001101100" foes="11111110110110001100001101100" cont="0"/>
+        <request index="11" response="00000000010010000011000000000" foes="01001000010010000011000000000" cont="0"/>
+        <request index="12" response="00000000110110000000001111100" foes="01001000110110000010001111100" cont="0"/>
+        <request index="13" response="10110100110110000000001101000" foes="10110100110110000000001101000" cont="0"/>
+        <request index="14" response="00000000000000000000000000000" foes="10000000000000000000000000000" cont="0"/>
+        <request index="15" response="00000000000000000000000000000" foes="10000100000000000000000001000" cont="0"/>
+        <request index="16" response="00000000000000000000000000000" foes="10101100001000011111101001000" cont="0"/>
+        <request index="17" response="00000000010000000000000110110" foes="11101100011000011011000110110" cont="1"/>
+        <request index="18" response="00000000000110000000000000000" foes="10100100000110000000001001000" cont="1"/>
+        <request index="19" response="00000000000000000000000000000" foes="11101100000100011111001001000" cont="0"/>
+        <request index="20" response="00000000000000000000000110100" foes="11101100000000011010000110100" cont="1"/>
+        <request index="21" response="10000000000000000000000000000" foes="10000000000000000000000000000" cont="0"/>
+        <request index="22" response="10000000000000000000000000100" foes="10000000000000000010000000100" cont="0"/>
+        <request index="23" response="00000000111111000000000101100" foes="00010000111111010010000101100" cont="0"/>
+        <request index="24" response="00100000110110001101101101100" foes="00110000110110011111101101100" cont="0"/>
+        <request index="25" response="10001100000000000000000100100" foes="10001100000000010010000100100" cont="0"/>
+        <request index="26" response="00000000111110000000001101100" foes="00001000111110010010001101100" cont="0"/>
+        <request index="27" response="00000000110100001101001101100" foes="00000000110100001101001101100" cont="0"/>
+        <request index="28" response="00000000111111100000000100100" foes="00010011111111110010000100100" cont="0"/>
     </junction>
-    <junction id="gneJ3" type="priority" x="-33.92" y="1.98" incLanes="-gneE2_0 -gneE2_1 -gneE2_2 -gneE7_0 -gneE7_1 -gneE7_2 -gneE5_0 -gneE5_1 -gneE5_2 -gneE3_0 -gneE3_1 -gneE3_2" intLanes=":gneJ3_0_0 :gneJ3_1_0 :gneJ3_2_0 :gneJ3_3_0 :gneJ3_4_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_7_0 :gneJ3_8_0 :gneJ3_9_0 :gneJ3_28_0 :gneJ3_29_0 :gneJ3_12_0 :gneJ3_30_0 :gneJ3_14_0 :gneJ3_15_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_18_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_21_0 :gneJ3_22_0 :gneJ3_23_0 :gneJ3_31_0 :gneJ3_32_0 :gneJ3_26_0 :gneJ3_33_0" shape="-25.69,8.89 -25.36,-4.51 -26.18,-4.69 -26.46,-4.91 -26.65,-5.20 -26.76,-5.58 -26.77,-6.04 -40.15,-6.77 -40.70,-5.11 -41.31,-4.47 -42.15,-3.96 -43.20,-3.57 -44.48,-3.32 -42.60,9.97 -41.79,10.02 -41.51,10.19 -41.32,10.45 -41.22,10.81 -41.21,11.26 -27.84,12.09 -27.51,10.29 -27.20,9.67 -26.79,9.22 -26.29,8.97">
-        <request index="0"  response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="1"  response="0000000000000000001000000000" foes="0000000000100000001000000000" cont="0"/>
-        <request index="2"  response="1111110000000001011000000000" foes="1111110100100001011000010000" cont="0"/>
-        <request index="3"  response="1101100011011011011000100000" foes="1101100011011011011000110000" cont="0"/>
-        <request index="4"  response="0000000000000001001000001100" foes="0000000100100001001000001100" cont="0"/>
-        <request index="5"  response="1111100000000011011000000000" foes="1111100100100011011000001000" cont="0"/>
-        <request index="6"  response="1101000011010011011000000000" foes="1101000011010011011000000000" cont="0"/>
-        <request index="7"  response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="8"  response="0000000000000000000000000000" foes="0001000000010000000000000000" cont="0"/>
-        <request index="9"  response="0000000000000000000000000000" foes="1001000010110000100001111110" cont="0"/>
-        <request index="10" response="0110110000000001000000000000" foes="1111110110110001100001101100" cont="1"/>
-        <request index="11" response="0000000000000000011000000000" foes="1001000010010000011000000000" cont="1"/>
-        <request index="12" response="0000000000000000000000000000" foes="1001000110110000010001111100" cont="0"/>
-        <request index="13" response="0110100000000000000000000000" foes="0110100110110000000001101000" cont="1"/>
-        <request index="14" response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="15" response="0000100000000000000000000000" foes="0000100000000000000000001000" cont="0"/>
-        <request index="16" response="0101100000000011111100000000" foes="0101100001000011111101001000" cont="0"/>
-        <request index="17" response="1101100010000011011000110110" foes="1101100011000011011000110110" cont="0"/>
-        <request index="18" response="0100100000110000000000000000" foes="0100100000110000000001001000" cont="0"/>
-        <request index="19" response="1101100000000011111000000000" foes="1101100000100011111001001000" cont="0"/>
-        <request index="20" response="1101100000000011010000110100" foes="1101100000000011010000110100" cont="0"/>
-        <request index="21" response="0000000000000000000000000000" foes="0000000000000000000000000000" cont="0"/>
-        <request index="22" response="0000000000000000000000000000" foes="0000000000000000010000000100" cont="0"/>
-        <request index="23" response="0000000000000000000000000000" foes="0010000111111010010000101100" cont="0"/>
-        <request index="24" response="0100000000000011111100000000" foes="0110000110110011111101101100" cont="1"/>
-        <request index="25" response="0001100000000000000000000000" foes="0001100000000010010000100100" cont="1"/>
-        <request index="26" response="0000000000000000000000000000" foes="0001000111110010010001101100" cont="0"/>
-        <request index="27" response="0000000000000001101000000000" foes="0000000110100001101001101100" cont="1"/>
+    <junction id="gneJ3" type="priority" x="-33.92" y="1.98" incLanes="-gneE2_0 -gneE2_1 -gneE2_2 -gneE7_0 -gneE7_1 -gneE7_2 -gneE5_0 -gneE5_1 -gneE5_2 -gneE3_0 -gneE3_1 -gneE3_2 :gneJ3_w2_0 :gneJ3_w4_0 :gneJ3_w6_0 :gneJ3_w0_0" intLanes=":gneJ3_0_0 :gneJ3_1_0 :gneJ3_2_0 :gneJ3_3_0 :gneJ3_4_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_7_0 :gneJ3_28_0 :gneJ3_9_0 :gneJ3_29_0 :gneJ3_30_0 :gneJ3_12_0 :gneJ3_31_0 :gneJ3_14_0 :gneJ3_15_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_18_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_21_0 :gneJ3_32_0 :gneJ3_23_0 :gneJ3_33_0 :gneJ3_34_0 :gneJ3_26_0 :gneJ3_35_0 :gneJ3_c0_0 :gneJ3_c1_0 :gneJ3_c2_0 :gneJ3_c3_0" shape="-25.69,8.89 -25.36,-4.51 -26.18,-4.69 -26.46,-4.91 -26.65,-5.20 -26.76,-5.58 -26.77,-6.04 -40.15,-6.77 -40.70,-5.11 -41.31,-4.47 -42.15,-3.96 -43.20,-3.57 -44.48,-3.32 -42.60,9.97 -41.79,10.02 -41.51,10.19 -41.32,10.45 -41.22,10.81 -41.21,11.26 -27.84,12.09 -27.51,10.29 -27.20,9.67 -26.79,9.22 -26.29,8.97">
+        <request index="0"  response="10000000000000000000000000000000" foes="10010000000000000000000000000000" cont="0"/>
+        <request index="1"  response="10000000000000000000001000000000" foes="10010000000000100000001000000000" cont="0"/>
+        <request index="2"  response="00001111110000000001011000000000" foes="01011111110100100001011000010000" cont="0"/>
+        <request index="3"  response="00101101100011011011011000100000" foes="00111101100011011011011000110000" cont="0"/>
+        <request index="4"  response="10000000000000000001001000001100" foes="10010000000100100001001000001100" cont="0"/>
+        <request index="5"  response="00001111100000000011011000000000" foes="01011111100100100011011000001000" cont="0"/>
+        <request index="6"  response="00101101000011010011011000000000" foes="00111101000011010011011000000000" cont="0"/>
+        <request index="7"  response="00110000000000000000000000000000" foes="00110000000000000000000000000000" cont="0"/>
+        <request index="8"  response="00110000000000000000000000000000" foes="00110001000000010000000000000000" cont="1"/>
+        <request index="9"  response="10100000000000000000000000000000" foes="10101001000010110000100001111110" cont="0"/>
+        <request index="10" response="01100110110000000001000000000000" foes="01101111110110110001100001101100" cont="1"/>
+        <request index="11" response="00110000000000000000011000000000" foes="00111001000010010000011000000000" cont="1"/>
+        <request index="12" response="10100000000000000000000000000000" foes="10101001000110110000010001111100" cont="0"/>
+        <request index="13" response="01100110100000000000000000000000" foes="01100110100110110000000001101000" cont="1"/>
+        <request index="14" response="00100000000000000000000000000000" foes="01100000000000000000000000000000" cont="0"/>
+        <request index="15" response="00100000100000000000000000000000" foes="01100000100000000000000000001000" cont="0"/>
+        <request index="16" response="00000101100000000011111100000000" foes="01010101100001000011111101001000" cont="0"/>
+        <request index="17" response="10001101100010000011011000110110" foes="11001101100011000011011000110110" cont="0"/>
+        <request index="18" response="00100100100000110000000000000000" foes="01100100100000110000000001001000" cont="0"/>
+        <request index="19" response="00001101100000000011111000000000" foes="01011101100000100011111001001000" cont="0"/>
+        <request index="20" response="10001101100000000011010000110100" foes="11001101100000000011010000110100" cont="0"/>
+        <request index="21" response="11000000000000000000000000000000" foes="11000000000000000000000000000000" cont="0"/>
+        <request index="22" response="11000000000000000000000000000000" foes="11000000000000000000010000000100" cont="1"/>
+        <request index="23" response="10100000000000000000000000000000" foes="10100010000111111010010000101100" cont="0"/>
+        <request index="24" response="10010100000000000011111100000000" foes="10010110000110110011111101101100" cont="1"/>
+        <request index="25" response="11000001100000000000000000000000" foes="11000001100000000010010000100100" cont="1"/>
+        <request index="26" response="10100000000000000000000000000000" foes="10100001000111110010010001101100" cont="0"/>
+        <request index="27" response="10010000000000000001101000000000" foes="10010000000110100001101001101100" cont="1"/>
+        <request index="28" response="00000000000010010000000001111111" foes="00001001000010010000100111111111" cont="0"/>
+        <request index="29" response="00000000000000000000000000000000" foes="00000100100001001111111111001000" cont="0"/>
+        <request index="30" response="00000000000111111100000000100100" foes="00000010011111111110010000100100" cont="0"/>
+        <request index="31" response="00000000000000000000000000000000" foes="00001111111100100001001000010011" cont="0"/>
     </junction>
     <junction id="gneJ4" type="priority" x="-125.02" y="58.38" incLanes="gneE4_0 gneE4_1 gneE5_0 gneE5_1 gneE5_2 -gneE17_0 -gneE17_1" intLanes=":gneJ4_0_0 :gneJ4_0_1 :gneJ4_2_0 :gneJ4_3_0 :gneJ4_4_0 :gneJ4_5_0 :gneJ4_6_0 :gneJ4_7_0" shape="-114.55,64.68 -114.68,51.88 -115.46,51.73 -115.70,51.53 -115.82,51.25 -115.85,50.89 -115.76,50.45 -128.61,46.72 -129.64,49.68 -130.15,50.72 -130.65,51.46 -131.16,51.91 -131.66,52.07 -131.49,64.86">
         <request index="0" response="00010000" foes="00010000" cont="0"/>
@@ -1080,15 +1307,17 @@
     <junction id=":gneJ2_28_0" type="internal" x="84.89" y="7.60" incLanes=":gneJ2_3_0 :gneJ2_17_0 gneE2_0 gneE2_1 gneE2_2" intLanes=":gneJ2_31_0 :gneJ2_5_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_14_0 :gneJ2_15_0 :gneJ2_16_0 :gneJ2_17_0 :gneJ2_18_0 :gneJ2_19_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_26_0 :gneJ2_27_0"/>
     <junction id=":gneJ2_29_0" type="internal" x="85.33" y="7.34" incLanes=":gneJ2_4_0 -gneE11_1" intLanes=":gneJ2_2_0 :gneJ2_3_0 :gneJ2_9_0 :gneJ2_12_0 :gneJ2_17_0 :gneJ2_20_0"/>
     <junction id=":gneJ2_30_0" type="internal" x="83.22" y="4.86" incLanes=":gneJ2_6_0 :gneJ2_17_0 gneE2_0 gneE2_1 gneE2_2" intLanes=":gneJ2_31_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_14_0 :gneJ2_15_0 :gneJ2_16_0 :gneJ2_17_0 :gneJ2_18_0 :gneJ2_19_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_26_0 :gneJ2_27_0"/>
-    <junction id=":gneJ2_31_0" type="internal" x="76.06" y="1.94" incLanes=":gneJ2_17_0 -gneE11_0 -gneE11_1 -gneE11_2" intLanes=":gneJ2_0_0 :gneJ2_1_0 :gneJ2_2_0 :gneJ2_3_0 :gneJ2_4_0 :gneJ2_5_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_19_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_26_0 :gneJ2_27_0"/>
-    <junction id=":gneJ2_32_0" type="internal" x="75.67" y="2.27" incLanes=":gneJ2_18_0 gneE2_1" intLanes=":gneJ2_3_0 :gneJ2_6_0 :gneJ2_16_0 :gneJ2_17_0 :gneJ2_23_0 :gneJ2_26_0"/>
-    <junction id=":gneJ2_33_0" type="internal" x="77.66" y="4.74" incLanes=":gneJ2_20_0 -gneE11_0 -gneE11_1 -gneE11_2" intLanes=":gneJ2_0_0 :gneJ2_1_0 :gneJ2_2_0 :gneJ2_3_0 :gneJ2_4_0 :gneJ2_5_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_26_0 :gneJ2_27_0"/>
-    <junction id=":gneJ3_28_0" type="internal" x="-30.58" y="-2.72" incLanes=":gneJ3_10_0 -gneE3_0 -gneE3_1 -gneE3_2" intLanes=":gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_12_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_21_0 :gneJ3_22_0 :gneJ3_23_0 :gneJ3_24_0 :gneJ3_25_0 :gneJ3_26_0"/>
-    <junction id=":gneJ3_29_0" type="internal" x="-31.23" y="-2.66" incLanes=":gneJ3_11_0 -gneE7_1" intLanes=":gneJ3_9_0 :gneJ3_10_0 :gneJ3_16_0 :gneJ3_19_0 :gneJ3_24_0 :gneJ3_27_0"/>
-    <junction id=":gneJ3_30_0" type="internal" x="-33.20" y="-1.34" incLanes=":gneJ3_13_0 -gneE3_0 -gneE3_1 -gneE3_2" intLanes=":gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_21_0 :gneJ3_22_0 :gneJ3_23_0 :gneJ3_24_0 :gneJ3_25_0 :gneJ3_26_0"/>
-    <junction id=":gneJ3_31_0" type="internal" x="-37.33" y="7.47" incLanes=":gneJ3_24_0 -gneE7_0 -gneE7_1 -gneE7_2 :gneJ3_10_0" intLanes=":gneJ3_28_0 :gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_7_0 :gneJ3_8_0 :gneJ3_9_0 :gneJ3_10_0 :gneJ3_11_0 :gneJ3_12_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_26_0"/>
-    <junction id=":gneJ3_32_0" type="internal" x="-36.74" y="7.65" incLanes=":gneJ3_25_0 -gneE3_1" intLanes=":gneJ3_2_0 :gneJ3_5_0 :gneJ3_10_0 :gneJ3_13_0 :gneJ3_23_0 :gneJ3_24_0"/>
-    <junction id=":gneJ3_33_0" type="internal" x="-34.62" y="5.73" incLanes=":gneJ3_27_0 -gneE7_0 -gneE7_1 -gneE7_2 :gneJ3_10_0" intLanes=":gneJ3_28_0 :gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_7_0 :gneJ3_8_0 :gneJ3_9_0 :gneJ3_10_0 :gneJ3_11_0 :gneJ3_12_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0"/>
+    <junction id=":gneJ2_31_0" type="internal" x="76.06" y="1.94" incLanes=":gneJ2_17_0 -gneE11_0 -gneE11_1 -gneE11_2" intLanes=":gneJ2_0_0 :gneJ2_1_0 :gneJ2_2_0 :gneJ2_3_0 :gneJ2_4_0 :gneJ2_5_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_19_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_26_0 :gneJ2_27_0 :gneJ2_c0_0"/>
+    <junction id=":gneJ2_32_0" type="internal" x="75.67" y="2.27" incLanes=":gneJ2_18_0 gneE2_1" intLanes=":gneJ2_3_0 :gneJ2_6_0 :gneJ2_16_0 :gneJ2_17_0 :gneJ2_23_0 :gneJ2_26_0 :gneJ2_c0_0"/>
+    <junction id=":gneJ2_33_0" type="internal" x="77.66" y="4.74" incLanes=":gneJ2_20_0 -gneE11_0 -gneE11_1 -gneE11_2" intLanes=":gneJ2_0_0 :gneJ2_1_0 :gneJ2_2_0 :gneJ2_3_0 :gneJ2_4_0 :gneJ2_5_0 :gneJ2_9_0 :gneJ2_10_0 :gneJ2_12_0 :gneJ2_13_0 :gneJ2_23_0 :gneJ2_24_0 :gneJ2_26_0 :gneJ2_27_0 :gneJ2_c0_0"/>
+    <junction id=":gneJ3_28_0" type="internal" x="-29.35" y="-4.29" incLanes=":gneJ3_8_0" intLanes=":gneJ3_16_0 :gneJ3_19_0 :gneJ3_24_0 :gneJ3_27_0 :gneJ3_c0_0 :gneJ3_c1_0"/>
+    <junction id=":gneJ3_29_0" type="internal" x="-30.58" y="-2.72" incLanes=":gneJ3_10_0 -gneE3_0 -gneE3_1 -gneE3_2" intLanes=":gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_12_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_21_0 :gneJ3_22_0 :gneJ3_23_0 :gneJ3_24_0 :gneJ3_25_0 :gneJ3_26_0 :gneJ3_c1_0 :gneJ3_c2_0"/>
+    <junction id=":gneJ3_30_0" type="internal" x="-31.23" y="-2.66" incLanes=":gneJ3_11_0 -gneE7_1" intLanes=":gneJ3_9_0 :gneJ3_10_0 :gneJ3_16_0 :gneJ3_19_0 :gneJ3_24_0 :gneJ3_27_0 :gneJ3_c0_0 :gneJ3_c1_0"/>
+    <junction id=":gneJ3_31_0" type="internal" x="-33.20" y="-1.34" incLanes=":gneJ3_13_0 -gneE3_0 -gneE3_1 -gneE3_2" intLanes=":gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_21_0 :gneJ3_22_0 :gneJ3_23_0 :gneJ3_24_0 :gneJ3_25_0 :gneJ3_26_0 :gneJ3_c1_0 :gneJ3_c2_0"/>
+    <junction id=":gneJ3_32_0" type="internal" x="-38.61" y="9.63" incLanes=":gneJ3_22_0" intLanes=":gneJ3_2_0 :gneJ3_5_0 :gneJ3_10_0 :gneJ3_13_0 :gneJ3_c2_0 :gneJ3_c3_0"/>
+    <junction id=":gneJ3_33_0" type="internal" x="-37.33" y="7.47" incLanes=":gneJ3_24_0 -gneE7_0 -gneE7_1 -gneE7_2 :gneJ3_10_0" intLanes=":gneJ3_29_0 :gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_7_0 :gneJ3_8_0 :gneJ3_9_0 :gneJ3_10_0 :gneJ3_11_0 :gneJ3_12_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_26_0 :gneJ3_c0_0 :gneJ3_c3_0"/>
+    <junction id=":gneJ3_34_0" type="internal" x="-36.74" y="7.65" incLanes=":gneJ3_25_0 -gneE3_1" intLanes=":gneJ3_2_0 :gneJ3_5_0 :gneJ3_10_0 :gneJ3_13_0 :gneJ3_23_0 :gneJ3_24_0 :gneJ3_c2_0 :gneJ3_c3_0"/>
+    <junction id=":gneJ3_35_0" type="internal" x="-34.62" y="5.73" incLanes=":gneJ3_27_0 -gneE7_0 -gneE7_1 -gneE7_2 :gneJ3_10_0" intLanes=":gneJ3_29_0 :gneJ3_2_0 :gneJ3_3_0 :gneJ3_5_0 :gneJ3_6_0 :gneJ3_7_0 :gneJ3_8_0 :gneJ3_9_0 :gneJ3_10_0 :gneJ3_11_0 :gneJ3_12_0 :gneJ3_16_0 :gneJ3_17_0 :gneJ3_19_0 :gneJ3_20_0 :gneJ3_c0_0 :gneJ3_c3_0"/>
     <junction id=":gneJ6_15_0" type="internal" x="-28.76" y="-49.28" incLanes=":gneJ6_8_0 -gneE14_1" intLanes=":gneJ6_7_0 :gneJ6_12_0 :gneJ6_14_0"/>
     <junction id=":gneJ6_16_0" type="internal" x="-31.36" y="-46.15" incLanes=":gneJ6_12_0 -gneE14_0 -gneE14_1 -gneE14_2" intLanes=":gneJ6_2_0 :gneJ6_4_0 :gneJ6_5_0 :gneJ6_6_0 :gneJ6_7_0 :gneJ6_8_0 :gneJ6_9_0 :gneJ6_13_0"/>
     <junction id=":gneJ6_17_0" type="internal" x="-31.54" y="-42.42" incLanes=":gneJ6_14_0 -gneE14_0 -gneE14_1 -gneE14_2" intLanes=":gneJ6_2_0 :gneJ6_4_0 :gneJ6_5_0 :gneJ6_6_0 :gneJ6_7_0 :gneJ6_8_0 :gneJ6_9_0"/>
@@ -1149,7 +1378,7 @@
     <connection from="-gneE19" to="-gneE18" fromLane="1" toLane="1" via=":gneJ15_3_0" dir="l" state="M"/>
     <connection from="-gneE19" to="gneE22" fromLane="2" toLane="0" via=":gneJ15_4_0" dir="r" state="m"/>
     <connection from="-gneE19" to="-gneE18" fromLane="2" toLane="2" via=":gneJ15_5_0" dir="l" state="M"/>
-    <connection from="-gneE2" to="gneE3" fromLane="0" toLane="0" via=":gneJ3_0_0" dir="r" state="M"/>
+    <connection from="-gneE2" to="gneE3" fromLane="0" toLane="0" via=":gneJ3_0_0" dir="r" state="m"/>
     <connection from="-gneE2" to="gneE3" fromLane="1" toLane="1" via=":gneJ3_1_0" dir="r" state="m"/>
     <connection from="-gneE2" to="gneE5" fromLane="1" toLane="1" via=":gneJ3_2_0" dir="s" state="m"/>
     <connection from="-gneE2" to="gneE7" fromLane="1" toLane="1" via=":gneJ3_3_0" dir="l" state="m"/>
@@ -1164,17 +1393,17 @@
     <connection from="-gneE21" to="-gneE18" fromLane="0" toLane="1" via=":gneJ15_0_0" dir="s" state="m"/>
     <connection from="-gneE21" to="-gneE18" fromLane="0" toLane="2" via=":gneJ15_0_1" dir="s" state="m"/>
     <connection from="-gneE21" to="gneE19" fromLane="0" toLane="2" via=":gneJ15_2_0" dir="l" state="m"/>
-    <connection from="-gneE3" to="gneE5" fromLane="0" toLane="0" via=":gneJ3_21_0" dir="r" state="M"/>
-    <connection from="-gneE3" to="gneE5" fromLane="1" toLane="1" via=":gneJ3_22_0" dir="r" state="M"/>
-    <connection from="-gneE3" to="gneE7" fromLane="1" toLane="1" via=":gneJ3_23_0" dir="s" state="M"/>
+    <connection from="-gneE3" to="gneE5" fromLane="0" toLane="0" via=":gneJ3_21_0" dir="r" state="m"/>
+    <connection from="-gneE3" to="gneE5" fromLane="1" toLane="1" via=":gneJ3_22_0" dir="r" state="m"/>
+    <connection from="-gneE3" to="gneE7" fromLane="1" toLane="1" via=":gneJ3_23_0" dir="s" state="m"/>
     <connection from="-gneE3" to="gneE2" fromLane="1" toLane="1" via=":gneJ3_24_0" dir="l" state="m"/>
     <connection from="-gneE3" to="gneE5" fromLane="2" toLane="2" via=":gneJ3_25_0" dir="r" state="m"/>
-    <connection from="-gneE3" to="gneE7" fromLane="2" toLane="2" via=":gneJ3_26_0" dir="s" state="M"/>
+    <connection from="-gneE3" to="gneE7" fromLane="2" toLane="2" via=":gneJ3_26_0" dir="s" state="m"/>
     <connection from="-gneE3" to="gneE2" fromLane="2" toLane="2" via=":gneJ3_27_0" dir="l" state="m"/>
     <connection from="-gneE4" to="-gneE3" fromLane="0" toLane="1" via=":gneJ0_5_0" dir="r" state="M"/>
     <connection from="-gneE4" to="-gneE3" fromLane="0" toLane="2" via=":gneJ0_6_0" dir="r" state="M"/>
     <connection from="-gneE4" to="gneE0" fromLane="1" toLane="1" via=":gneJ0_7_0" dir="s" state="m"/>
-    <connection from="-gneE5" to="gneE7" fromLane="0" toLane="0" via=":gneJ3_14_0" dir="r" state="M"/>
+    <connection from="-gneE5" to="gneE7" fromLane="0" toLane="0" via=":gneJ3_14_0" dir="r" state="m"/>
     <connection from="-gneE5" to="gneE7" fromLane="1" toLane="1" via=":gneJ3_15_0" dir="r" state="m"/>
     <connection from="-gneE5" to="gneE2" fromLane="1" toLane="1" via=":gneJ3_16_0" dir="s" state="m"/>
     <connection from="-gneE5" to="gneE3" fromLane="1" toLane="1" via=":gneJ3_17_0" dir="l" state="m"/>
@@ -1184,12 +1413,12 @@
     <connection from="-gneE6" to="-gneE0" fromLane="0" toLane="0" via=":gneJ1_0_0" dir="s" state="m"/>
     <connection from="-gneE6" to="-gneE0" fromLane="1" toLane="1" via=":gneJ1_0_1" dir="s" state="m"/>
     <connection from="-gneE6" to="gneE1" fromLane="1" toLane="2" via=":gneJ1_2_0" dir="l" state="m"/>
-    <connection from="-gneE7" to="gneE2" fromLane="0" toLane="0" via=":gneJ3_7_0" dir="r" state="M"/>
-    <connection from="-gneE7" to="gneE2" fromLane="1" toLane="1" via=":gneJ3_8_0" dir="r" state="M"/>
-    <connection from="-gneE7" to="gneE3" fromLane="1" toLane="1" via=":gneJ3_9_0" dir="s" state="M"/>
+    <connection from="-gneE7" to="gneE2" fromLane="0" toLane="0" via=":gneJ3_7_0" dir="r" state="m"/>
+    <connection from="-gneE7" to="gneE2" fromLane="1" toLane="1" via=":gneJ3_8_0" dir="r" state="m"/>
+    <connection from="-gneE7" to="gneE3" fromLane="1" toLane="1" via=":gneJ3_9_0" dir="s" state="m"/>
     <connection from="-gneE7" to="gneE5" fromLane="1" toLane="1" via=":gneJ3_10_0" dir="l" state="m"/>
     <connection from="-gneE7" to="gneE2" fromLane="2" toLane="2" via=":gneJ3_11_0" dir="r" state="m"/>
-    <connection from="-gneE7" to="gneE3" fromLane="2" toLane="2" via=":gneJ3_12_0" dir="s" state="M"/>
+    <connection from="-gneE7" to="gneE3" fromLane="2" toLane="2" via=":gneJ3_12_0" dir="s" state="m"/>
     <connection from="-gneE7" to="gneE5" fromLane="2" toLane="2" via=":gneJ3_13_0" dir="l" state="m"/>
     <connection from="-gneE8" to="-gneE7" fromLane="0" toLane="0" via=":gneJ6_0_0" dir="r" state="M"/>
     <connection from="-gneE8" to="-gneE7" fromLane="1" toLane="1" via=":gneJ6_1_0" dir="r" state="m"/>
@@ -1206,7 +1435,7 @@
     <connection from="gneE0" to="gneE1" fromLane="0" toLane="1" via=":gneJ1_5_0" dir="r" state="M"/>
     <connection from="gneE0" to="gneE1" fromLane="0" toLane="2" via=":gneJ1_6_0" dir="r" state="M"/>
     <connection from="gneE0" to="gneE6" fromLane="1" toLane="1" via=":gneJ1_7_0" dir="s" state="m"/>
-    <connection from="gneE1" to="-gneE2" fromLane="0" toLane="0" via=":gneJ2_21_0" dir="r" state="M"/>
+    <connection from="gneE1" to="-gneE2" fromLane="0" toLane="0" via=":gneJ2_21_0" dir="r" state="m"/>
     <connection from="gneE1" to="-gneE2" fromLane="1" toLane="1" via=":gneJ2_22_0" dir="r" state="m"/>
     <connection from="gneE1" to="gneE9" fromLane="1" toLane="1" via=":gneJ2_23_0" dir="s" state="m"/>
     <connection from="gneE1" to="gneE11" fromLane="1" toLane="1" via=":gneJ2_24_0" dir="l" state="m"/>
@@ -1399,15 +1628,16 @@
     <connection from=":gneJ3_5" to="gneE5" fromLane="0" toLane="2" dir="s" state="M"/>
     <connection from=":gneJ3_6" to="gneE7" fromLane="0" toLane="2" dir="l" state="M"/>
     <connection from=":gneJ3_7" to="gneE2" fromLane="0" toLane="0" dir="r" state="M"/>
-    <connection from=":gneJ3_8" to="gneE2" fromLane="0" toLane="1" dir="r" state="M"/>
+    <connection from=":gneJ3_8" to="gneE2" fromLane="0" toLane="1" via=":gneJ3_28_0" dir="r" state="m"/>
+    <connection from=":gneJ3_28" to="gneE2" fromLane="0" toLane="1" dir="r" state="M"/>
     <connection from=":gneJ3_9" to="gneE3" fromLane="0" toLane="1" dir="s" state="M"/>
-    <connection from=":gneJ3_10" to="gneE5" fromLane="0" toLane="1" via=":gneJ3_28_0" dir="l" state="m"/>
-    <connection from=":gneJ3_28" to="gneE5" fromLane="0" toLane="1" dir="l" state="M"/>
-    <connection from=":gneJ3_11" to="gneE2" fromLane="0" toLane="2" via=":gneJ3_29_0" dir="r" state="m"/>
-    <connection from=":gneJ3_29" to="gneE2" fromLane="0" toLane="2" dir="r" state="M"/>
+    <connection from=":gneJ3_10" to="gneE5" fromLane="0" toLane="1" via=":gneJ3_29_0" dir="l" state="m"/>
+    <connection from=":gneJ3_29" to="gneE5" fromLane="0" toLane="1" dir="l" state="M"/>
+    <connection from=":gneJ3_11" to="gneE2" fromLane="0" toLane="2" via=":gneJ3_30_0" dir="r" state="m"/>
+    <connection from=":gneJ3_30" to="gneE2" fromLane="0" toLane="2" dir="r" state="M"/>
     <connection from=":gneJ3_12" to="gneE3" fromLane="0" toLane="2" dir="s" state="M"/>
-    <connection from=":gneJ3_13" to="gneE5" fromLane="0" toLane="2" via=":gneJ3_30_0" dir="l" state="m"/>
-    <connection from=":gneJ3_30" to="gneE5" fromLane="0" toLane="2" dir="l" state="M"/>
+    <connection from=":gneJ3_13" to="gneE5" fromLane="0" toLane="2" via=":gneJ3_31_0" dir="l" state="m"/>
+    <connection from=":gneJ3_31" to="gneE5" fromLane="0" toLane="2" dir="l" state="M"/>
     <connection from=":gneJ3_14" to="gneE7" fromLane="0" toLane="0" dir="r" state="M"/>
     <connection from=":gneJ3_15" to="gneE7" fromLane="0" toLane="1" dir="r" state="M"/>
     <connection from=":gneJ3_16" to="gneE2" fromLane="0" toLane="1" dir="s" state="M"/>
@@ -1416,15 +1646,16 @@
     <connection from=":gneJ3_19" to="gneE2" fromLane="0" toLane="2" dir="s" state="M"/>
     <connection from=":gneJ3_20" to="gneE3" fromLane="0" toLane="2" dir="l" state="M"/>
     <connection from=":gneJ3_21" to="gneE5" fromLane="0" toLane="0" dir="r" state="M"/>
-    <connection from=":gneJ3_22" to="gneE5" fromLane="0" toLane="1" dir="r" state="M"/>
+    <connection from=":gneJ3_22" to="gneE5" fromLane="0" toLane="1" via=":gneJ3_32_0" dir="r" state="m"/>
+    <connection from=":gneJ3_32" to="gneE5" fromLane="0" toLane="1" dir="r" state="M"/>
     <connection from=":gneJ3_23" to="gneE7" fromLane="0" toLane="1" dir="s" state="M"/>
-    <connection from=":gneJ3_24" to="gneE2" fromLane="0" toLane="1" via=":gneJ3_31_0" dir="l" state="m"/>
-    <connection from=":gneJ3_31" to="gneE2" fromLane="0" toLane="1" dir="l" state="M"/>
-    <connection from=":gneJ3_25" to="gneE5" fromLane="0" toLane="2" via=":gneJ3_32_0" dir="r" state="m"/>
-    <connection from=":gneJ3_32" to="gneE5" fromLane="0" toLane="2" dir="r" state="M"/>
+    <connection from=":gneJ3_24" to="gneE2" fromLane="0" toLane="1" via=":gneJ3_33_0" dir="l" state="m"/>
+    <connection from=":gneJ3_33" to="gneE2" fromLane="0" toLane="1" dir="l" state="M"/>
+    <connection from=":gneJ3_25" to="gneE5" fromLane="0" toLane="2" via=":gneJ3_34_0" dir="r" state="m"/>
+    <connection from=":gneJ3_34" to="gneE5" fromLane="0" toLane="2" dir="r" state="M"/>
     <connection from=":gneJ3_26" to="gneE7" fromLane="0" toLane="2" dir="s" state="M"/>
-    <connection from=":gneJ3_27" to="gneE2" fromLane="0" toLane="2" via=":gneJ3_33_0" dir="l" state="m"/>
-    <connection from=":gneJ3_33" to="gneE2" fromLane="0" toLane="2" dir="l" state="M"/>
+    <connection from=":gneJ3_27" to="gneE2" fromLane="0" toLane="2" via=":gneJ3_35_0" dir="l" state="m"/>
+    <connection from=":gneJ3_35" to="gneE2" fromLane="0" toLane="2" dir="l" state="M"/>
     <connection from=":gneJ4_0" to="gneE17" fromLane="0" toLane="0" dir="s" state="M"/>
     <connection from=":gneJ4_0" to="gneE17" fromLane="1" toLane="1" dir="s" state="M"/>
     <connection from=":gneJ4_2" to="-gneE5" fromLane="0" toLane="2" dir="l" state="M"/>
@@ -1494,4 +1725,160 @@
     <connection from=":gneJ7_26" to="gneE16" fromLane="0" toLane="2" dir="s" state="M"/>
     <connection from=":gneJ7_27" to="gneE13" fromLane="0" toLane="2" dir="l" state="M"/>
 
+    <connection from=":gneJ0_w0" to="-gneE3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ0_w0" to="gneE4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ0_w0" to="gneE0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE4" to=":gneJ0_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE0" to=":gneJ0_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE3" to=":gneJ0_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ0_w1" to="-gneE3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE3" to=":gneJ0_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ1_w0" to="gneE1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ1_w0" to="-gneE0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ1_w0" to="gneE6" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE0" to=":gneJ1_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE6" to=":gneJ1_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE1" to=":gneJ1_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ1_w1" to="gneE1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE1" to=":gneJ1_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ10_w0" to="-gneE12" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE18" to=":gneJ10_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ10_w1" to="gneE18" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE18" to=":gneJ10_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ10_w2" to="gneE18" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE13" to=":gneJ10_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ10_w3" to="-gneE13" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE13" to=":gneJ10_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ10_w4" to="-gneE13" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE12" to=":gneJ10_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ10_w5" to="-gneE12" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE12" to=":gneJ10_w5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ12_w0" to="-gneE14" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE15" to=":gneJ12_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ12_w1" to="gneE15" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE15" to=":gneJ12_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ12_w2" to="gneE15" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE14" to=":gneJ12_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ12_w3" to="-gneE14" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE14" to=":gneJ12_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ13_w0" to="-gneE16" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE20" to=":gneJ13_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ13_w1" to="gneE20" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE20" to=":gneJ13_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ13_w2" to="gneE20" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE15" to=":gneJ13_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ13_w3" to="-gneE15" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE15" to=":gneJ13_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ13_w4" to="-gneE15" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE16" to=":gneJ13_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ13_w5" to="-gneE16" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE16" to=":gneJ13_w5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ14_w0" to="-gneE17" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE17" to=":gneJ14_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ15_w1" to="gneE19" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE19" to=":gneJ15_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ15_w2" to="gneE19" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE18" to=":gneJ15_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ15_w3" to="-gneE18" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE18" to=":gneJ15_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ16_w0" to="-gneE19" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE20" to=":gneJ16_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ16_w1" to="-gneE20" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE20" to=":gneJ16_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ16_w2" to="-gneE20" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE19" to=":gneJ16_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ16_w3" to="-gneE19" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE19" to=":gneJ16_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_c0" to=":gneJ2_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w0" to="-gneE1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE11" to=":gneJ2_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w1" to="gneE11" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE11" to=":gneJ2_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w2" to="gneE11" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE9" to=":gneJ2_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w3" to="gneE9" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE9" to=":gneJ2_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w4" to="gneE9" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE2" to=":gneJ2_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w5" to="-gneE2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE2" to=":gneJ2_w5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w6" to=":gneJ2_c0" fromLane="0" toLane="0" dir="s" state="m"/>
+    <connection from=":gneJ2_w6" to="-gneE2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE1" to=":gneJ2_w6" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ2_w7" to="-gneE1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE1" to=":gneJ2_w7" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_c0" to=":gneJ3_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_c1" to=":gneJ3_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_c2" to=":gneJ3_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_c3" to=":gneJ3_w6" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w0" to=":gneJ3_c3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w0" to="gneE3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE2" to=":gneJ3_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w1" to="gneE2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE2" to=":gneJ3_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w2" to=":gneJ3_c0" fromLane="0" toLane="0" dir="s" state="m"/>
+    <connection from=":gneJ3_w2" to="gneE2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE7" to=":gneJ3_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w3" to="gneE7" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE7" to=":gneJ3_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w4" to=":gneJ3_c1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w4" to="gneE7" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE5" to=":gneJ3_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w5" to="gneE5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE5" to=":gneJ3_w5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w6" to=":gneJ3_c2" fromLane="0" toLane="0" dir="s" state="m"/>
+    <connection from=":gneJ3_w6" to="gneE5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE3" to=":gneJ3_w6" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ3_w7" to="gneE3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE3" to=":gneJ3_w7" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ4_w0" to="-gneE5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ4_w0" to="gneE17" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ4_w0" to="-gneE4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE17" to=":gneJ4_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE4" to=":gneJ4_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE5" to=":gneJ4_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ4_w1" to="-gneE5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE5" to=":gneJ4_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ5_w0" to="gneE12" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ5_w0" to="-gneE6" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ5_w0" to="gneE10" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE6" to=":gneJ5_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE10" to=":gneJ5_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE12" to=":gneJ5_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ5_w1" to="gneE12" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE12" to=":gneJ5_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ6_w0" to="-gneE7" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE8" to=":gneJ6_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ6_w1" to="gneE8" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE8" to=":gneJ6_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ6_w2" to="gneE8" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE14" to=":gneJ6_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ6_w3" to="gneE14" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE14" to=":gneJ6_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ6_w4" to="gneE14" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE7" to=":gneJ6_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ6_w5" to="-gneE7" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE7" to=":gneJ6_w5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w0" to="-gneE9" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE13" to=":gneJ7_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w1" to="gneE13" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE13" to=":gneJ7_w1" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w2" to="gneE13" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE16" to=":gneJ7_w2" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w3" to="gneE16" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="-gneE16" to=":gneJ7_w3" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w4" to="gneE16" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE8" to=":gneJ7_w4" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w5" to="-gneE8" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE8" to=":gneJ7_w5" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w6" to="-gneE8" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE9" to=":gneJ7_w6" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ7_w7" to="-gneE9" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE9" to=":gneJ7_w7" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ8_w0" to="-gneE10" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE10" to=":gneJ8_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ9_w0" to="-gneE11" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE11" to=":gneJ9_w0" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":gneJ9_w1" to="-gneE11" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from="gneE11" to=":gneJ9_w1" fromLane="0" toLane="0" dir="s" state="M"/>
 </net>

--- a/SumoNetVis/Net.py
+++ b/SumoNetVis/Net.py
@@ -62,7 +62,7 @@ class _Edge:
         :type attrib: dict
         """
         self.id = attrib["id"]
-        self.function = attrib["function"] if "function" in attrib else ""
+        self.function = attrib["function"] if "function" in attrib else "normal"
         self.lanes = []
 
     def append_lane(self, lane):

--- a/SumoNetVis/Net.py
+++ b/SumoNetVis/Net.py
@@ -20,6 +20,7 @@ COLOR_SCHEME = {
     "authority": "#FF0000",
     "none": "#FFFFFF",
     "no_passenger": "#5C5C5C",
+    "crosswalk": "#00000000",
     "other": "#000000"
 }
 USA_STYLE = "USA"
@@ -179,7 +180,10 @@ class _Lane:
         :return: lane type
         """
         if self.allow == "pedestrian":
-            return "pedestrian"
+            if self.parentEdge is not None and self.parentEdge.function == "crossing":
+                return "crosswalk"
+            else:
+                return "pedestrian"
         if self.allow == "bicycle":
             return "bicycle"
         if self.allow == "ship":
@@ -344,6 +348,10 @@ class _Lane:
         """
         markings = []
         if self.parentEdge.function == "internal" or self.allow == "ship" or self.allow == "rail":
+            return markings
+        if self.parentEdge.function == "crossing":
+            color, dashes = "w", (0.5, 0.5)
+            markings.append({"line": self.alignment, "lw": self.width, "color": color, "dashes": dashes})
             return markings
         # US-style markings
         if LANE_MARKINGS_STYLE == USA_STYLE:

--- a/SumoNetVis/Net.py
+++ b/SumoNetVis/Net.py
@@ -595,6 +595,8 @@ class Net:
         net = ET.parse(file).getroot()
         for obj in net:
             if obj.tag == "edge":
+                if "function" in obj.attrib and obj.attrib["function"] == "walkingarea":
+                    continue
                 edge = _Edge(obj.attrib)
                 for laneObj in obj:
                     lane = _Lane(laneObj.attrib)

--- a/SumoNetVis/Net.py
+++ b/SumoNetVis/Net.py
@@ -694,6 +694,10 @@ class Net:
             ax = plt.gca()
         if junction_kwargs is None:
             junction_kwargs = dict()
+        if lane_kwargs is None:
+            lane_kwargs = dict()
+        if lane_marking_kwargs is None:
+            lane_marking_kwargs = dict()
         if zoom_to_extents and not clip_to_limits:
             x_min, y_min, x_max, y_max = self._get_extents()
             ax.set_xlim(x_min, x_max)
@@ -705,10 +709,10 @@ class Net:
         window = Polygon(bounds)
         for edge in self.edges:
             if edge.function != "internal" and (not clip_to_limits or edge.intersects(window)):
-                edge.plot(ax, lane_kwargs, lane_marking_kwargs, **kwargs)
+                edge.plot(ax, {"zorder": -100, **lane_kwargs}, {"zorder": -90, **lane_marking_kwargs}, **kwargs)
         for junction in self.junctions:
             if not clip_to_limits or (junction.shape is not None and junction.shape.intersects(window)):
-                junction.plot(ax, **{**kwargs, **junction_kwargs})
+                junction.plot(ax, **{"zorder": -110, **kwargs, **junction_kwargs})
 
 
 if __name__ == "__main__":

--- a/SumoNetVis/Net.py
+++ b/SumoNetVis/Net.py
@@ -656,8 +656,9 @@ class Net:
             if edge.function == "internal":
                 continue
             for lane in edge.lanes:
-                lane_content, vertex_count = lane.generate_obj_text(vertex_count)
-                content += lane_content
+                if edge.function not in ["crossing", "walkingarea"]:
+                    lane_content, vertex_count = lane.generate_obj_text(vertex_count)
+                    content += lane_content
                 markings_content, vertex_count = lane.generate_markings_obj_text(vertex_count=vertex_count)
                 content += markings_content
         for junction in self.junctions:

--- a/SumoNetVis/Net.py
+++ b/SumoNetVis/Net.py
@@ -152,7 +152,6 @@ class _Lane:
         coords = [[float(coord) for coord in xy.split(",")] for xy in attrib["shape"].split(" ")]
         self.alignment = LineString(coords)
         self.shape = self.alignment.buffer(self.width/2, cap_style=CAP_STYLE.flat)
-        self.color = self.lane_color()
         self.parentEdge = None
 
     def allows(self, vClass):
@@ -224,7 +223,7 @@ class _Lane:
         """
         if "lw" not in kwargs and "linewidth" not in kwargs:
             kwargs["lw"] = 0
-        poly = matplotlib.patches.Polygon(self.shape.boundary.coords, True, color=self.color, **kwargs)
+        poly = matplotlib.patches.Polygon(self.shape.boundary.coords, True, color=self.lane_color(), **kwargs)
         ax.add_patch(poly)
 
     def inverse_lane_index(self):

--- a/SumoNetVis/_Utils.py
+++ b/SumoNetVis/_Utils.py
@@ -34,6 +34,7 @@ class LineDataUnits(Line2D):
         _lw_data = kwargs.pop("linewidth", 1)
         _dashes_data = kwargs.pop("dashes", (1,))
         super().__init__(*args, **kwargs)
+        self.set_linestyle("--")
         self._lw_data = _lw_data
         self._dashes_data = _dashes_data
         self._dashOffset = 0
@@ -53,7 +54,8 @@ class LineDataUnits(Line2D):
         if self.axes is not None:
             ppd = 72./self.axes.figure.dpi
             trans = self.axes.transData.transform
-            return tuple([((trans((1, dash_data))-trans((0, 0)))*ppd)[1] for dash_data in self._dashes_data])
+            dpu = (trans((1, 1)) - trans((0, 0)))[0]
+            return tuple([u*dpu*ppd for u in self._dashes_data])
         else:
             return tuple((1, 0))
 


### PR DESCRIPTION
Resolves #4 

* Adds support for crosswalks in plotting and OBJ export
* Fixes bug with lane marking dash distances, where calculation of points from real-world distances was incorrect
* Fixes crash when line buffer operation results in a MultiPolygon