### PR TITLE
Colorbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ SumoNetVis.COLOR_SCHEME["bicycle"] = "#006600"
 Any color specification supported by matplotlib can be given here, such as RGB and RGBA hex strings and float tuples, as
 well as color names and abbreviations. See the matplotlib documentation for more detailed information.
 
+### Trajectory Colorization
+When using the various "assign_colors" functions, when applicable, a corresponding matplotlib ```ScalarMappable``` will
+be stored in the ```Trajectory.mappable``` property. The ```Trajectories``` class also contains a property,
+```mappables```, which contains a dict of ```vehID: ScalarMappable``` pairs. Therefore, to automatically generate a
+colorbar, one of the two following (equivalent) methods can be used:
+
+```python
+plt.colorbar(trajectories["vehicle_id"].mappable)
+# OR
+plt.colorbar(trajectories.mappables["vehicle_id"])
+```
+
 ### Animation
 Instead of visualizing Trajectories as lines, an animation can be generated using the ```matplotlib.animation``` module.
 

--- a/SumoNetVis/Trajectory.py
+++ b/SumoNetVis/Trajectory.py
@@ -14,6 +14,11 @@ GENERIC_PARAM_MISSING_VALUE = None  # value to assign for timesteps when a gener
 
 
 class Trajectory:
+    """
+    Class containing a single trajectory.
+
+    :ivar mappable: ``ScalarMappable`` object. Useful for generating colorbars. None if no applicable colorization.
+    """
     def __init__(self, id, type, time=None, x=None, y=None, speed=None, angle=None, lane=None, colors=None, params=None):
         self.id = id
         self.type = type
@@ -30,6 +35,10 @@ class Trajectory:
 
     @property
     def mappable(self):
+        """
+        ``ScalarMappable`` object corresponding to colorization of trajectory. Useful for generating colorbars, like so:
+        ``plt.colorbar(trajectory.mappable)``
+        """
         return self._mappable
 
     def _append_point(self, time, x, y, speed=None, angle=None, lane=None, color="#000000", params=None):
@@ -343,6 +352,10 @@ class Trajectories:
 
     @property
     def mappables(self):
+        """
+        dict of ``vehID: ScalarMappable`` pairs. Useful for generating colorbars, like so:
+        ``plt.colorbar(trajectories.mappables[vehID])``
+        """
         return {traj.id: traj.mappable for traj in self.trajectories if traj.mappable is not None}
 
     def plot(self, ax=None, start_time=0, end_time=np.inf, **kwargs):


### PR DESCRIPTION
Add generation of and access to matplotlib ```ScalarMappable``` objects corresponding to Trajectory colorization (when applicable). This allows for easier creation of colorbar(s).